### PR TITLE
CHEF-25066 - decommission  - add_archive_note_to_readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Archived Repository
+
+This repository has been archived and will no longer receive updates. 
+It was archived as part of the [Repository Standardization Initiative](https://github.com/chef-boneyard/oss-repo-standardization-2025).
+If you are a Chef customer and need support for this repository, please contact your Chef account team.
+
 # InSpec Profile for testing inputs with audit cookbook
 
 This is a simple profile that allows for testing inputs in an inspec run. You define the `test_file_path` input and InSpec will test that the file exists.


### PR DESCRIPTION
This PR adds an archive notice to the top of the README.md to indicate that this repository is no longer maintained and has been archived as part of the Repository Standardization Initiative.